### PR TITLE
fix extends instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ taxonomies = [
 
 - To replace the copyright field, create your own `templates/index.html` to extend the template and add a `copyright` block:
 ```
-{% extends "themes/zola-clean-blog/templates/index.html" %}
+{% extends "zola-clean-blog/templates/index.html" %}
 {% block copyright %}
 Copyright %copy; Example, Inc. 2016-2019
 {% endblock copyright %}

--- a/README.md
+++ b/README.md
@@ -54,3 +54,19 @@ Copyright %copy; Example, Inc. 2016-2019
 </script>
 {% endblock analytics %}
 ```
+
+## Sidebar automatic links
+
+Merged a little bit of Sidebar formatting from the Dinkleberg theme. To add
+sidebar entries add this to the config in the '[extra]' section
+
+```
+sidebar = [
+    {name = "Social", urls=[
+        {name="Github", url="https://github.com"},
+    ]},
+    {name = "Hello World", urls=[
+        {name="Hi", url="https://pages.github.com"}
+    ]}
+]
+```

--- a/sass/_global.scss
+++ b/sass/_global.scss
@@ -24,7 +24,7 @@ h6 {
 }
 
 a {
-  color: $gray-900;
+  color: $color-link;
   @include transition-all;
   &:focus,
   &:hover {
@@ -52,6 +52,18 @@ blockquote {
   text-align: center;
   border-bottom-right-radius: 5px;
   border-bottom-left-radius: 5px;
+}
+.container {
+  max-width: 1024px;
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.container-main {
+    flex: 2 1;
+    padding: 10px;
+    /*width: 95%;*/
+    /*border: 2px solid red;*/
 }
 
 ::-moz-selection {

--- a/sass/_sidebar.scss
+++ b/sass/_sidebar.scss
@@ -1,0 +1,34 @@
+
+.container-sidebar {
+    /*width: 35%;*/
+    /*display: none;*/
+    flex: 0 0 800px;
+
+    @media screen and (min-width: 900px) {
+        /*width: 30%;*/
+        /*display: block;*/
+        flex: 1 1;
+        /*width: 400px;*/
+    }
+
+    h3 {
+        margin: 0 0 5px;
+        padding: 0 5px 5px;
+        color: $black;
+        border-bottom: 1px solid $gray-200;
+    }
+}
+
+.sidebar-list {
+    list-style: none;
+    padding: 0 15px;
+
+    & > li > a {
+        text-decoration: none;
+        color: $color-link;
+    }
+
+    li {
+        margin-bottom: 10px;
+    }
+}

--- a/sass/_variables.scss
+++ b/sass/_variables.scss
@@ -31,3 +31,4 @@ $warning:       $yellow !default;
 $danger:        $red !default;
 $light:         $gray-100 !default;
 $dark:          $gray-800 !default;
+$color-link:    $blue     !default;

--- a/sass/clean-blog.scss
+++ b/sass/clean-blog.scss
@@ -7,3 +7,4 @@
 @import "contact.scss";
 @import "footer.scss";
 @import "bootstrap-overrides.scss";
+@import "sidebar.scss";

--- a/templates/about.html
+++ b/templates/about.html
@@ -2,7 +2,13 @@
 
 {% block header %}
 <!-- Page Header -->
-<header class="masthead" style="background-image: url('{{ get_url(path="/img/about-bg.jpg")}}')">
+{% if not page.extra.bg_img %}
+    <!-- if front matter doesn't set it -->
+    {% set bg_img = "/img/about-bg.jpg" %}
+{% else %}
+    {% set bg_img = page.extra.bg_img %}
+{% endif %}
+<header class="masthead" style="background-image: url('{{ get_url(path=bg_img)}}')">
   <div class="overlay">
   </div>
   <div class="container">

--- a/templates/about.html
+++ b/templates/about.html
@@ -9,8 +9,19 @@
     <div class="row">
       <div class="col-lg-8 col-md-10 mx-auto">
         <div class="page-heading">
-          <h1>About Me</h1>
-          <span class="subheading">This is what I do.</span>
+          {% if page.title %}
+            {% set about_title = page.title %}
+          {% else %}
+            {% set about_title = "About Me" %}
+          {% endif %}
+          <h1>{{ about_title }}</h1>
+
+          {% if page.extra.about_subhead %}
+            {% set about_subhead = page.extra.about_subhead %}
+          {% else %}
+            {% set about_subhead = "This is what I do..." %}
+          {% endif %}
+          <span class="subheading">{{ about_subhead }}</span>
         </div>
       </div>
     </div>

--- a/templates/about.html
+++ b/templates/about.html
@@ -12,8 +12,8 @@
   <div class="overlay">
   </div>
   <div class="container">
-    <div class="row">
-      <div class="col-lg-8 col-md-10 mx-auto">
+    <div class="container-main">
+      <div class="mx-auto">
         <div class="page-heading">
           {% if page.title %}
             {% set about_title = page.title %}
@@ -38,10 +38,14 @@
 {% block content %}
 <!-- Main Content -->
 <div class="container">
-  <div class="row">
-    <div class="col-lg-8 col-md-10 mx-auto">
+  <div class="container-main">
+    <div class="mx-auto">
       {{ page.content | safe }}
     </div>
   </div>
 </div>
 {% endblock content %}
+
+{# don't show the sidebar on about pages #}
+{% block sidebar %}
+{% endblock sidebar %}

--- a/templates/contact.html
+++ b/templates/contact.html
@@ -20,8 +20,8 @@
 {% block content %}
 <!-- Main Content -->
 <div class="container">
-  <div class="row">
-    <div class="col-lg-8 col-md-10 mx-auto">
+  <div class="container-main">
+    <div class="mx-auto">
       <p>Want to get in touch? Fill out the form below to send me a message and I will get back to you as soon as
         possible!</p>
       <form name="contact" method="POST" {%if config.extra.netlify_forms %}data-netlify="true" {%endif%}>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,4 +1,6 @@
+
 {% import "post_macros.html" as post_macros %}
+
 
 <!DOCTYPE html>
 <html lang="en">
@@ -55,7 +57,14 @@
 
   <!-- Page Header -->
   {% block header %}
-  <header class="masthead" style="background-image: url('{{ get_url(path="/img/home-bg.jpg")}}')">
+  {% set bg_img_default = "/img/home-bg.jpg" %}
+  {% if not page.extra.bg_img %}
+      <!-- if front matter doesn't set it -->
+      {% set bg_img = bg_img_default %}
+  {% else %}
+      {% set bg_img = page.extra.bg_img %}
+  {% endif %}
+  <header class="masthead" style="background-image: url('{{ get_url(path=bg_img)}}')">
     <div class="overlay">
     </div>
     <div class="container">

--- a/templates/index.html
+++ b/templates/index.html
@@ -89,8 +89,8 @@
           {% for page in paginator.pages %}
           <div class="post-preview">
             {{ post_macros::page_title(page=page) }}
-            <p class="post-summary">{{ page.summary | safe }}</p>
-            <i class="float-right" ><a href="{{ page.permalink }}">More Info</a></i>
+              <p class="post-summary">{{ page.summary | safe }}</p>
+              <i class="float-right"><a href="{{ page.permalink }}">More Info</a></i><br/>
           </div>
           {% endfor %}
         </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -81,6 +81,7 @@
           <div class="post-preview">
             {{ post_macros::page_title(page=page) }}
             <p class="post-summary">{{ page.summary | safe }}</p>
+            <i class="float-right" ><a href="{{ page.permalink }}">More Info</a></i>
           </div>
           {% endfor %}
         </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -80,11 +80,11 @@
   </header>
   {% endblock header %}
 
+  <div class="container">
   {% block content %}
   <!-- Main Content -->
-  <div class="container">
-    <div class="row">
-      <div class="col-lg-8 col-md-10 mx-auto">
+    <div class="container-main">
+      <div class="mx-auto">
         <div class="posts">
           {% for page in paginator.pages %}
           <div class="post-preview">
@@ -107,16 +107,30 @@
 
       </div>
     </div>
-  </div>
   {% endblock content %}
 
-  <hr>
+  {%- block sidebar %}
+    <div class="container-sidebar">
+        {%- for sidebar in config.extra.sidebar %}
+            <h3>{{ sidebar.name }}</h3>
+            <ul class="sidebar-list">
+                {%- for item in sidebar.urls %}
+                    <li>
+                        <a href="{{item.url}}">{{item.name}}</a>
+                    </li>
+                {% endfor %}
+            </ul>
+        {%- endfor %}
+    </div>
+  {% endblock sidebar %}
+  </div>
+  <!-- <hr> -->
 
   <!-- Footer -->
   <footer>
     <div class="container">
-      <div class="row">
-        <div class="col-lg-8 col-md-10 mx-auto">
+      <div class="container-main">
+        <div class="col-md-10 mx-auto">
           <ul class="list-inline text-center">
             {% for item in config.extra.clean_blog_social %}
             <li class="list-inline-item">

--- a/templates/page.html
+++ b/templates/page.html
@@ -1,8 +1,15 @@
 {% extends "index.html" %}
 
 {% block header %}
+{% set bg_img_default = "/img/post-bg.jpg" %}
+{% if not page.extra.bg_img %}
+    <!-- if front matter doesn't set it -->
+    {% set bg_img = bg_img_default %}
+{% else %}
+    {% set bg_img = page.extra.bg_img %}
+{% endif %}
 <!-- Page Header -->
-<header class="masthead" style="background-image: url('{{ get_url(path="/img/post-bg.jpg")}}')">
+<header class="masthead" style="background-image: url('{{ get_url(path=bg_img)}}')">
   <div class="overlay"></div>
   <div class="container">
     <div class="row">

--- a/templates/page.html
+++ b/templates/page.html
@@ -27,8 +27,8 @@
 <!-- Post Content -->
 <article>
   <div class="container">
-    <div class="row">
-      <div class="col-lg-8 col-md-10 mx-auto">
+    <div class="container-main">
+      <div class="mx-auto">
         {{ page.content | safe }}
         {% if page.taxonomies.tags %}
         <div class="post-tags">
@@ -44,3 +44,7 @@
   </div>
 </article>
 {% endblock content %}
+
+{# don't show the sidebar on post pages #}
+{% block sidebar %}
+{% endblock sidebar %}


### PR DESCRIPTION
Existing instructions cause a error on zola check
Error: Template 'index.html' is inheriting from 'themes/zola-clean-blog/templates/index.html', which doesn't exist or isn't loaded.

Knocking off themes lets the path resolve