### PR TITLE
index.html broken when running under `zola serve`

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -33,7 +33,7 @@
   <!-- Navigation -->
   <nav class="navbar navbar-expand-lg navbar-light fixed-top" id="mainNav">
     <div class="container">
-      <a class="navbar-brand" href="index.html">{{config.title}}</a>
+      <a class="navbar-brand" href="{{ config.base_url }}">{{config.title}}</a>
       <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse"
         data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false"
         aria-label="Toggle navigation">


### PR DESCRIPTION
When running under `zola serve` I get a `404` when I try to use this navigation.  Also it is a relative path when I think it is supposed to be explicitly set back to the blogs homepage.